### PR TITLE
speed up calculate_coobs x3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Imports:
 Suggests: 
     knitr (>= 1.33.0),
     rmarkdown (>= 2.7.0),
+    Rfast,
     testthat (>= 3.0.0),
     doParallel (>= 1.0.16),
     doSNOW (>= 1.0.19),

--- a/R/calculate_coobs.R
+++ b/R/calculate_coobs.R
@@ -139,7 +139,8 @@ calculate_coobs <- function(mraster,
   progress <- function(n) utils::setTxtProgressBar(pb, n)
   opts <- list(progress = progress)
   M <- as.matrix(vals[, 3:ncol(vals)])
-  i <- sample(1:nrow(M), 10000)
+  sample <- nrow(M) > 10000
+  if (sample) i <- sample(1:nrow(M), 10000)
   
   `%dopar%` <- foreach::`%dopar%`
   
@@ -156,7 +157,10 @@ calculate_coobs <- function(mraster,
     #--- Determine min and max distance values for each ---#
     
     pixMin <- min(pixDist)
-    pixMax <- stats::quantile(pixDist[i], probs = threshold)
+    if (sample)
+      pixMax <- stats::quantile(pixDist[i], probs = threshold)
+    else
+      pixMax <- stats::quantile(pixDist, probs = threshold)
     
     #--- Determine distance for each sample location ---#
     

--- a/R/calculate_coobs.R
+++ b/R/calculate_coobs.R
@@ -51,169 +51,172 @@ calculate_coobs <- function(mraster,
                             details = FALSE,
                             filename = NULL,
                             overwrite = FALSE) {
-
+  
   #--- check for required packages ---#
   if (!requireNamespace("doParallel", quietly = TRUE)) {
     stop("Packages \"doParallel\" needed for this function to work. Please install it.",
-      call. = FALSE
+         call. = FALSE
     )
   }
-
+  
   if (!requireNamespace("doSNOW", quietly = TRUE)) {
     stop("Package \"doSNOW\" needed for this function to work. Please install it.",
-      call. = FALSE
+         call. = FALSE
     )
   }
-
+  
   if (!requireNamespace("foreach", quietly = TRUE)) {
     stop("Packages \"foreach\" needed for this function to work. Please install it.",
-      call. = FALSE
+         call. = FALSE
     )
   }
-
+  
   if (!requireNamespace("snow", quietly = TRUE)) {
     stop("Package \"snow\" needed for this function to work. Please install it.",
-      call. = FALSE
+         call. = FALSE
     )
   }
-
+  
   #--- set global vars ---#
-
+  
   i <- geometry <- NULL
-
+  
   #--- Error handling ---#
-
+  
   if (!inherits(mraster, "SpatRaster")) {
     stop("'mraster' must be type SpatRaster")
   }
-
+  
   if (!inherits(existing, "data.frame") && !inherits(existing, "sf")) {
     stop("'existing' must be a data.frame or sf object")
   }
-
+  
   if (!is.numeric(threshold)) {
     stop("'threshold' must be type numeric")
   }
-
+  
   if (!is.logical(details)) {
     stop("'details' must be type logical")
   }
-
+  
   nb <- terra::nlyr(mraster)
-
+  
   if (nb < 2) {
     stop("'mraster' only has 1 band. Need at least 2 bands to calculate covariance matrix")
   }
-
+  
   #--- extract covariates data from mraster ---#
-
+  
   vals <- terra::as.data.frame(mraster, xy = TRUE, row.names = FALSE)
-
+  
   #--- Remove NA / NaN / Inf values ---#
-
+  
   vals <- vals %>%
     dplyr::filter(stats::complete.cases(.))
-
+  
   #--- Generate covariance matrix ---#
-
+  
   covMat <- as.matrix(stats::cov(vals[, 3:ncol(vals)]))
-
+  
   #--- select geometry attribute ---#
-
+  
   existing <- existing %>%
     dplyr::select(geometry)
-
+  
   #--- extract covariates at existing sample locations ---#
-
+  
   samples <- sgsR::extract_metrics(mraster, existing, data.frame = TRUE)
-
+  
   #--- create parallel processing structure ---#
-
+  
   cl <- snow::makeCluster(spec = cores, type = "SOCK")
   doSNOW::registerDoSNOW(cl)
-
+  
   #--- create progress text bar ---#
-
+  
   iterations <- nrow(vals)
   pb <- utils::txtProgressBar(max = iterations, style = 3)
   progress <- function(n) utils::setTxtProgressBar(pb, n)
   opts <- list(progress = progress)
-
+  M <- as.matrix(vals[, 3:ncol(vals)])
+  i <- sample(1:nrow(M), 10000)
+  
   `%dopar%` <- foreach::`%dopar%`
-
+  
   #--- iterate parallel processing of mahalanobis distance ---#
-
+  
   loop <- foreach::foreach(i = 1:iterations, .combine = "c", .options.snow = opts) %dopar% {
     cell <- vals[i, 3:ncol(vals)]
-
+    
     #--- Determine distance for each pixel in raster ---#
-
-    pixDist <- stats::mahalanobis(x = as.matrix(vals[, 3:ncol(vals)]), center = as.matrix(cell), cov = covMat)
-
+    
+    pixDist <- Rfast::mahala(x = M, mu = as.matrix(cell), s = covMat)
+    
+    
     #--- Determine min and max distance values for each ---#
-
+    
     pixMin <- min(pixDist)
-    pixMax <- stats::quantile(pixDist, probs = threshold)
-
+    pixMax <- stats::quantile(pixDist[i], probs = threshold)
+    
     #--- Determine distance for each sample location ---#
-
-    sampDist <- stats::mahalanobis(x = as.matrix(samples[, 3:ncol(samples)]), center = as.matrix(cell), cov = covMat) # calculate distance of observations to all other pixels
-
+    
+    sampDist <- Rfast::mahala(x = as.matrix(samples[, 3:ncol(samples)]), mu = as.matrix(cell), s = covMat) # calculate distance of observations to all other pixels
+    
     #--- Normalize distance between data and samples)
-
+    
     sampNDist <- (sampDist - pixMin) / (pixMax - pixMin)
-
+    
     #--- If sampDist > 1 sampDist > maxDist ---#
-
+    
     sampNDist[sampNDist > 1] <- 1
-
+    
     #--- larger values equate to more similarity ---#
-
+    
     sampNDist <- 1 - sampNDist
-
+    
     #--- establish count above threshold ---#
-
+    
     sum(sampNDist >= threshold)
   }
-
+  
   close(pb)
-
+  
   #--- End parallel ---#
   snow::stopCluster(cl)
-
+  
   #--- Coerce output from parallel to a new attribute in covariates ---#
-
+  
   vals$nSamp <- loop
-
+  
   #--- convert nSamp to raster ---#
-
+  
   r <- terra::rast(as.matrix(vals[, c("x", "y", "nSamp")]), type = "xyz")
   names(r) <- "COOB"
-
+  
   #--- classify raster into breaks on the fly ---#
-
+  
   breaks <- unique(floor(seq(min(vals$nSamp), max(vals$nSamp), length.out = 8)))
-
+  
   rc <- terra::classify(r, breaks, include.lowest = TRUE, right = FALSE)
   names(rc) <- "COOBclass"
-
+  
   #--- stack 2 rasters for output ---#
-
+  
   rout <- c(r, rc)
-
+  
   #--- Plot output ---#
-
+  
   if (isTRUE(plot)) {
-
+    
     #--- plot ---#
-
+    
     terra::plot(rc)
     terra::plot(existing, add = TRUE)
   }
-
+  
   if (!is.null(filename)) {
     terra::writeRaster(rout, filename, overwrite = overwrite)
   }
-
+  
   return(rout)
 }


### PR DESCRIPTION
This is a 3-folds speed-up for `calculate_coobs`. I changed two things

- I'm using `Rfast::mahala` instead of `stats::mahalanobis`
- I'm computing quantiles on a subset of 10000 values. Computing quantiles require to sort the vector which is a costly step ran in loop multiple time. By subsetting the vector to max 10000 values allows to get correct estimation of the actual 95th percentile without spending much time on this step.

I benchmarked up to 10%. Old code: 60 seconds. New code: 20 seconds. I still think parallelism is not useful and the problem can be solved faster by doing the math differently but this is not a trivial function to optimize.