### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-utils-plot.R
+++ b/tests/testthat/test-utils-plot.R
@@ -15,6 +15,12 @@ test_that("scatter errors", {
 test_that("scatter messages", {
   expect_message(plot_scatter(mraster = mraster, existing = existing), "More than 2 layers in `mraster`. Only first 2 layers will be used.")
   expect_s3_class(o, "gg")
-  expect_equal(o$labels$x, "zq90")
-  expect_equal(o1$labels$x, "pzabove2")
+  
+  get_labs <- function(x) x$labels
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    get_labs <- ggplot2::get_labs
+  }
+  
+  expect_equal(get_labs(o)$x, "zq90")
+  expect_equal(get_labs(o1)$x, "pzabove2")
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the sgsR package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun